### PR TITLE
feat: Add an option to configure on which level(s) of heading the rule should be enforced

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,16 +3,20 @@ const titleCase = require('ap-style-title-case');
 
 const DEFAULT_OPTIONS = {
 	exclusions: [],
+	headingLevels: []
 };
 
-function reporter(context) {
-	const opts = Object.assign({}, DEFAULT_OPTIONS);
+function reporter(context, opts = {}) {
+	const options = { ...DEFAULT_OPTIONS, ...opts };
 	const { Syntax, RuleError, report, fixer } = context;
 	return {
 		[Syntax.Header](node) {
+			if (options.headingLevels.length > 0 && !options.headingLevels.includes(node.depth)) {
+				return false;
+			}
 			return new Promise(resolve => {
 				const text = getText(node);
-				const replacement = updateCase(text, opts.exclusions);
+				const replacement = updateCase(text, options.exclusions);
 				if (text !== replacement) {
 					const index = getFirstStrIndex(node);
 					const range = [index, index + text.length];

--- a/test.js
+++ b/test.js
@@ -86,3 +86,75 @@ tester.run('textlint-rule-terminology', rule, {
 		},
 	],
 });
+
+tester.run(
+	'textlint-rule-title-case',
+	{
+		rules: [
+			{
+				ruleId: 'title-case',
+				rule,
+				options: {
+					headingLevels: [1]
+				},
+			},
+		],
+	},
+	{
+		valid: [
+			{
+				// The rule should only be applied on document title (level 1)
+				// The document title (level 1) is using AP/APA title case but the section title (level 2) is *not*
+				text: '# This Is a Title\n\n## This is a subtitle',
+			},
+		],
+		invalid: [
+			{
+				text: '# This is a title\n\n## This Is a Subtitle',
+				output: '# This Is a Title\n\n## This Is a Subtitle',
+				errors: [
+					{
+						message:
+							'Incorrect title casing: “This is a title”, use “This Is a Title” instead',
+					},
+				],
+			},
+		],
+	}
+);
+
+tester.run(
+	'textlint-rule-title-case',
+	{
+		rules: [
+			{
+				ruleId: 'title-case',
+				rule,
+				options: {
+					exclusions: [
+						'reveal.js'
+					]
+				},
+			},
+		],
+	},
+	{
+		valid: [
+			{
+				text: '# reveal.js Configuration Options',
+			},
+		],
+		invalid: [
+			{
+				text: '# node.js Configuration Options',
+				output: '# Node.js Configuration Options',
+				errors: [
+					{
+						message:
+							'Incorrect title casing: “node.js Configuration Options”, use “Node.js Configuration Options” instead',
+					},
+				],
+			},
+		],
+	}
+);


### PR DESCRIPTION
Also fixes a bug where `exclusions` option was ignored.
I wonder if we should take this opportunity to rename the option to `exclude` (as stop-words and terminology are already using `exclude`)?

resolves #7