### PR TITLE
feat!: Rename `exclusions` to `exclude`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,7 @@ You can configure the rule in your `.textlintrc`:
   "rules": {
     "title-case": {
       // Always use this casing for these words
-      "exclusions": [
+      "exclude": [
         "npm",
         "webpack"
       ],

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const StringSource = require("textlint-util-to-string").StringSource;
 const titleCase = require('ap-style-title-case');
 
 const DEFAULT_OPTIONS = {
-	exclusions: [],
+	exclude: [],
 	headingLevels: []
 };
 
@@ -16,7 +16,7 @@ function reporter(context, opts = {}) {
 			}
 			return new Promise(resolve => {
 				const text = getText(node);
-				const replacement = updateCase(text, options.exclusions);
+				const replacement = updateCase(text, options.exclude);
 				if (text !== replacement) {
 					const index = getFirstStrIndex(node);
 					const range = [index, index + text.length];

--- a/test.js
+++ b/test.js
@@ -32,7 +32,7 @@ describe('getText', () => {
 });
 
 describe('updateCase', () => {
-	test('exclusions', () => {
+	test('exclude', () => {
 		expect(updateCase('what is an npm package', ['npm'])).toBe('What Is an npm Package');
 	});
 	test('ignore case', () => {
@@ -131,7 +131,7 @@ tester.run(
 				ruleId: 'title-case',
 				rule,
 				options: {
-					exclusions: [
+					exclude: [
 						'reveal.js'
 					]
 				},


### PR DESCRIPTION
Hi,

based on my promise from https://github.com/sapegin/textlint-rule-title-case/pull/8#issuecomment-1274930274 I have prepared rename of `exclusions` to `exclude`.

I have also noticed that the variable `exclusions` is used in the `updateCase` function, but I did not intentionally rename it.

Looking forward for a merge and new version release ;-)