### PR TITLE
docs: Add configuration example of `headingLevels` (#8)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,6 +44,8 @@ You can configure the rule in your `.textlintrc`:
 {
   "rules": {
     "title-case": {
+      // Apply these rules only for mentioned heading levels
+      "headingLevels": [1, 2, 3],
       // Always use this casing for these words
       "exclude": [
         "npm",


### PR DESCRIPTION
Hi,

I have also noticed that there has been missing documentation of introduced `headingLevels` which were added in https://github.com/sapegin/textlint-rule-title-case/pull/8.

So I have extended the example documentation with this configuration. :-)